### PR TITLE
GHM-459 Create a generic Terraform module for an AWS Delphix instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# terraform-external
-Externally visible Terraform modules.
+Copyright (c) 2022 by Delphix. All rights reserved.
+
+# About
+
+This repository contains a Terraform module to create a generic Delphix
+instances in various clouds.

--- a/delphix-instance/aws/README.md
+++ b/delphix-instance/aws/README.md
@@ -1,0 +1,82 @@
+Copyright (c) 2022 by Delphix. All rights reserved.
+
+# About
+
+This repository contains a Terraform module to create a generic Delphix
+instance in AWS.
+
+This module can be invoked as follows
+
+```
+module "delphix_instance" {
+    source          = "./delphix-instance"
+
+    region          = "us-west-2"
+    hosted_zone     = "testing-hosted-zone"      # Replace with a hosted zone name
+    instance_name   = "testing-instance"         # Replace with a name for the instance
+    image_id        = "test-ami-id"              # Replace with a Delphix AMI ID
+    instance_size   = "t3.large"
+    creator         = "test-creator"             # Replace with the creator, used for tagging
+    owner           = "test-owner"               # Replace with the owner, used for tagging
+    subnet          = "test-subnet-id"           # Replace with the subnet ID for the instance
+    security_groups = ["test-security-group-id"] # Replace with the security group ID for the instance
+    tags = {
+        test = "test"                            # Replace this with tags to apply to all applicable resources
+    }
+}
+
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ebs_volume.data_disk](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) | resource |
+| [aws_instance.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_route53_record.dns_a_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.dns_txt_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_volume_attachment.data_disk_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
+| [aws_route53_zone.dns_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_creator"></a> [creator](#input\_creator) | Instance creator, used for tagging | `string` | n/a | yes |
+| <a name="input_data_disks"></a> [data\_disks](#input\_data\_disks) | Map of data disks to create and attach to instance | <pre>map(<br>    object({<br>      device_name = string<br>      size        = number<br>      type        = string<br>      iops        = number<br>      throughput  = number<br>  }))</pre> | <pre>{<br>  "/dev/sde": {<br>    "device_name": "/dev/sde",<br>    "iops": null,<br>    "size": 8,<br>    "throughput": null,<br>    "type": "gp3"<br>  },<br>  "/dev/sdf": {<br>    "device_name": "/dev/sdf",<br>    "iops": null,<br>    "size": 8,<br>    "throughput": null,<br>    "type": "gp3"<br>  },<br>  "/dev/sdg": {<br>    "device_name": "/dev/sdg",<br>    "iops": null,<br>    "size": 8,<br>    "throughput": null,<br>    "type": "gp3"<br>  }<br>}</pre> | no |
+| <a name="input_hosted_zone"></a> [hosted\_zone](#input\_hosted\_zone) | Hosted zone name to create a Route53 record in | `string` | `""` | no |
+| <a name="input_image_id"></a> [image\_id](#input\_image\_id) | AMI image ID used for main instance | `string` | n/a | yes |
+| <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name of new instance | `string` | n/a | yes |
+| <a name="input_instance_profile_name"></a> [instance\_profile\_name](#input\_instance\_profile\_name) | Name of an IAM instance profile to attach to the instance | `string` | `null` | no |
+| <a name="input_instance_size"></a> [instance\_size](#input\_instance\_size) | AWS instance size | `string` | `"t3.large"` | no |
+| <a name="input_owner"></a> [owner](#input\_owner) | Instance owner, used for tagging | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | `"us-west-2"` | no |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | List of IDs of security groups for the instance | `list(string)` | n/a | yes |
+| <a name="input_subnet"></a> [subnet](#input\_subnet) | ID of the subnet for the instance | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to tag all resources with | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | n/a |
+| <a name="output_instance_ip"></a> [instance\_ip](#output\_instance\_ip) | n/a |
+<!-- END_TF_DOCS -->

--- a/delphix-instance/aws/dns.tf
+++ b/delphix-instance/aws/dns.tf
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2022 by Delphix. All rights reserved.
+#
+
+locals {
+  instance_host_name = var.hosted_zone != "" ? "${var.instance_name}.${data.aws_route53_zone.dns_zone[0].name}" : ""
+}
+
+data "aws_route53_zone" "dns_zone" {
+  count = var.hosted_zone != "" ? 1 : 0
+  name  = var.hosted_zone
+  private_zone = true
+}
+
+resource "aws_route53_record" "dns_a_record" {
+  count      = var.hosted_zone != "" ? 1 : 0
+  depends_on = [aws_instance.instance]
+  zone_id    = data.aws_route53_zone.dns_zone[0].zone_id
+  name       = local.instance_host_name
+  type       = "A"
+  ttl        = "300"
+  records    = [aws_instance.instance.private_ip]
+}
+
+resource "aws_route53_record" "dns_txt_record" {
+  count   = var.hosted_zone != "" ? 1 : 0
+  zone_id = data.aws_route53_zone.dns_zone[0].zone_id
+  name    = local.instance_host_name
+  type    = "TXT"
+  ttl     = "300"
+  records = ["{\\\"name\\\": \\\"${var.instance_name}\\\",\\\"user\\\": \\\"${var.owner}\\\"}"]
+}

--- a/delphix-instance/aws/instance.tf
+++ b/delphix-instance/aws/instance.tf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2022 by Delphix. All rights reserved.
+#
+
+resource "aws_instance" "instance" {
+  ami                    = var.image_id
+  instance_type          = var.instance_size
+  subnet_id              = var.subnet
+  vpc_security_group_ids = var.security_groups
+  iam_instance_profile   = var.instance_profile_name
+}

--- a/delphix-instance/aws/outputs.tf
+++ b/delphix-instance/aws/outputs.tf
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2022 by Delphix. All rights reserved.
+#
+
+output "instance_id" {
+  value = aws_instance.instance.id
+}
+
+output "instance_ip" {
+  value = aws_instance.instance.private_ip
+}

--- a/delphix-instance/aws/provider.tf
+++ b/delphix-instance/aws/provider.tf
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2022 by Delphix. All rights reserved.
+#
+
+variable "region" {
+  description = "AWS region"
+  default     = "us-west-2"
+}
+
+locals {
+  tags = merge({
+    "Name"       = var.instance_name
+    "Creator"    = var.creator
+    "Owner"      = var.owner
+  }, var.tags)
+}
+
+provider "aws" {
+  region       = var.region
+  default_tags {
+    tags = local.tags
+  }
+}
+
+terraform {
+  required_version = "~> 1.1"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/delphix-instance/aws/vars.tf
+++ b/delphix-instance/aws/vars.tf
@@ -1,0 +1,92 @@
+#
+# Copyright (c) 2022 by Delphix. All rights reserved.
+#
+
+variable "data_disks" {
+  description = "Map of data disks to create and attach to instance"
+  type = map(
+    object({
+      device_name = string
+      size        = number
+      type        = string
+      iops        = number
+      throughput  = number
+  }))
+  default = {
+    "/dev/sde" : {
+      "device_name" : "/dev/sde"
+      "size" : 8
+      "type" : "gp3"
+      "iops" : null
+      "throughput" : null
+    },
+    "/dev/sdf" : {
+      "device_name" : "/dev/sdf"
+      "size" : 8
+      "type" : "gp3"
+      "iops" : null
+      "throughput" : null
+    },
+    "/dev/sdg" : {
+      "device_name" : "/dev/sdg"
+      "size" : 8
+      "type" : "gp3"
+      "iops" : null
+      "throughput" : null
+    }
+  }
+}
+
+variable "instance_name" {
+  description = "Name of new instance"
+  type        = string
+}
+
+variable "image_id" {
+  description = "AMI image ID used for main instance"
+  type        = string
+}
+
+variable "instance_size" {
+  description = "AWS instance size"
+  type        = string
+  default     = "t3.large"
+}
+
+variable "instance_profile_name" {
+  description = "Name of an IAM instance profile to attach to the instance"
+  type = string
+  default = null
+}
+
+variable "creator" {
+  description = "Instance creator, used for tagging"
+  type        = string
+}
+
+variable "owner" {
+  description = "Instance owner, used for tagging"
+  type        = string
+}
+
+variable "hosted_zone" {
+  description = "Hosted zone name to create a Route53 record in"
+  type        = string
+  default     = ""
+}
+
+variable "subnet" {
+  description = "ID of the subnet for the instance"
+  type        = string
+}
+
+variable "security_groups" {
+  description = "List of IDs of security groups for the instance"
+  type        = list(string)
+}
+
+variable "tags" {
+  description = "Map of tags to tag all resources with"
+  type        = map(string)
+  default = {}
+}

--- a/delphix-instance/aws/volumes.tf
+++ b/delphix-instance/aws/volumes.tf
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2022 by Delphix. All rights reserved.
+#
+
+resource "aws_ebs_volume" "data_disk" {
+  for_each = var.data_disks
+
+  availability_zone = aws_instance.instance.availability_zone
+  size              = each.value.size
+  type              = each.value.type
+  iops              = each.value.iops
+  throughput        = each.value.throughput
+}
+
+resource "aws_volume_attachment" "data_disk_attachment" {
+  for_each = var.data_disks
+
+  device_name = each.value.device_name
+  instance_id = aws_instance.instance.id
+  volume_id   = aws_ebs_volume.data_disk[each.key].id
+}


### PR DESCRIPTION
### Background
Terraform is a useful tool to manage infrastructure as code and to
do infrastructure deploys with minimal configurations.

### Problem
We do not have any generic examples of how to deploy a Delphix
engine with Terraform that we can point customers to.

### Solution
Create a generic Terraform template that can be used to deploy a
Delphix engine in AWS

### Testing Done
Called the `aws` module in a test template and ensured I could
run `terraform apply` and deploy a Delphix engine.
